### PR TITLE
Update photon_osalloc.nim

### DIFF
--- a/photon_jit/photon_osalloc.nim
+++ b/photon_jit/photon_osalloc.nim
@@ -8,8 +8,9 @@ const PageSize* = 4096
 
 when defined(windows):
   type MemProt* {.size: cint.sizeof.} = enum
-    ProtReadWrite = 0x04 # Page can be read or written to
     ProtReadExec  = 0x02 # Page can be read or executed from
+    ProtReadWrite = 0x04 # Page can be read or written to
+    
 else:
   type MemProt* {.size: cint.sizeof.} = enum
     # is *not* a flag on Win32!


### PR DESCRIPTION
else, latest nim says
```
photon-jit-master\photon_jit\photon_osalloc.nim(12, 21) Error: invalid order in enum 'ProtReadExec'
```